### PR TITLE
Optimize `aten.ceil()` with custom Mojo kernel

### DIFF
--- a/torch_max_backend/aten_functions.py
+++ b/torch_max_backend/aten_functions.py
@@ -1071,14 +1071,20 @@ def aten_ceil(input: TensorValue) -> TensorValue:
     """
     Ceiling of the input tensor, element-wise.
 
-    For floating-point inputs: Implemented as ceil(x) = -floor(-x) since MAX has floor operation available.
+    For floating-point inputs: Uses a custom Mojo kernel for efficient ceil operation.
     For integer inputs: Returns it (no mathematical change needed, following PyTorch behavior).
     """
     if input.type.dtype.is_integral():
         return input
     else:
-        # TODO: Make a Mojo custom op that does this in one single step
-        return -max_ops.floor(-input)
+        return max_ops.custom(
+            name="ceil",
+            device=input.device,
+            values=[input],
+            out_types=[
+                TensorType(dtype=input.dtype, shape=input.shape, device=input.device)
+            ],
+        )[0]
 
 
 # clamp(Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor

--- a/torch_max_backend/mojo_kernels/math.mojo
+++ b/torch_max_backend/mojo_kernels/math.mojo
@@ -1,0 +1,33 @@
+from compiler import register
+from gpu.host import DeviceContext
+from gpu.id import block_idx
+from layout import LayoutTensor
+from math import ceil
+from runtime.asyncrt import DeviceContextPtr
+from tensor_internal import InputTensor, OutputTensor, foreach
+
+from utils.index import IndexList
+
+
+@compiler.register("ceil")
+struct CeilKernel:
+    @staticmethod
+    fn execute[
+        dtype: DType,
+        rank: Int,
+        //,
+        target: StaticString,
+    ](
+        output: OutputTensor[dtype = dtype, rank = rank],
+        x: InputTensor[dtype = dtype, rank = rank],
+        ctx: DeviceContextPtr,
+    ) raises:
+
+        @parameter
+        @always_inline
+        fn elementwise_ceil[
+            width: Int
+        ](idx: IndexList[x.rank]) -> SIMD[x.dtype, width]:
+            return ceil(x.load[width](idx))
+
+        foreach[elementwise_ceil, target=target](output, ctx)

--- a/torch_max_backend/mojo_kernels/math.mojo
+++ b/torch_max_backend/mojo_kernels/math.mojo
@@ -1,33 +1,13 @@
 from compiler import register
-from gpu.host import DeviceContext
-from gpu.id import block_idx
-from layout import LayoutTensor
 from math import ceil
-from runtime.asyncrt import DeviceContextPtr
-from tensor_internal import InputTensor, OutputTensor, foreach
-
-from utils.index import IndexList
+from tensor_internal import ElementwiseUnaryOp
 
 
 @compiler.register("ceil")
-struct CeilKernel:
+struct CeilKernel(ElementwiseUnaryOp):
     @staticmethod
-    fn execute[
+    fn elementwise[
         dtype: DType,
-        rank: Int,
-        //,
-        target: StaticString,
-    ](
-        output: OutputTensor[dtype = dtype, rank = rank],
-        x: InputTensor[dtype = dtype, rank = rank],
-        ctx: DeviceContextPtr,
-    ) raises:
-
-        @parameter
-        @always_inline
-        fn elementwise_ceil[
-            width: Int
-        ](idx: IndexList[x.rank]) -> SIMD[x.dtype, width]:
-            return ceil(x.load[width](idx))
-
-        foreach[elementwise_ceil, target=target](output, ctx)
+        width: Int,
+    ](x: SIMD[dtype, width]) -> SIMD[dtype, width]:
+        return ceil(x)


### PR DESCRIPTION
Replace the two-step operation (`-floor(-x)`) with a single efficient Mojo kernel implementation for improved performance.

Changes:
- Add `math.mojo` kernel with `CeilKernel` implementation
- Update `aten_ceil()` to use `max_ops.custom()` with the new kernel
