### PR TITLE
Implement `aten.select_scatter()`

### DIFF
--- a/tests/test_aten_functions.py
+++ b/tests/test_aten_functions.py
@@ -1182,6 +1182,89 @@ def test_aten_trigon_scalar_tensor(device: str, fn: Callable):
     check_functions_are_equivalent(fn, device, [x])
 
 
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_aten_select_scatter_basic_2d(device: str, dtype: torch.dtype):
+    """Test aten.select_scatter basic functionality with 2D tensors"""
+
+    def fn(self, src):
+        return aten.select_scatter(self, src, dim=0, index=1)
+
+    # Replace row 1 with new values
+    self = torch.zeros(3, 4, dtype=dtype, device=device)
+    src = torch.ones(4, dtype=dtype, device=device) * 5
+
+    check_functions_are_equivalent(fn, device, [self, src])
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.int32, torch.int64])
+def test_aten_select_scatter_dim1(device: str, dtype: torch.dtype):
+    """Test aten.select_scatter along dimension 1"""
+
+    def fn(self, src):
+        return aten.select_scatter(self, src, dim=1, index=2)
+
+    # Replace column 2 with new values
+    self = torch.zeros(3, 4, dtype=dtype, device=device)
+    src = torch.ones(3, dtype=dtype, device=device) * 7
+
+    check_functions_are_equivalent(fn, device, [self, src])
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_aten_select_scatter_3d_tensor(device: str, dtype: torch.dtype):
+    """Test aten.select_scatter with 3D tensor"""
+    if device == "cpu" and dtype == torch.float16:
+        pytest.skip("float16 not supported on CPU in MAX")
+
+    def fn(self, src):
+        return aten.select_scatter(self, src, dim=1, index=2)
+
+    # Replace middle slice along dimension 1
+    self = torch.zeros(2, 4, 3, dtype=dtype, device=device)
+    src = torch.randn(2, 3, dtype=dtype, device=device)
+
+    check_functions_are_equivalent(fn, device, [self, src])
+
+
+def test_aten_select_scatter_negative_dim(device: str):
+    """Test aten.select_scatter with negative dimension"""
+
+    def fn(self, src):
+        return aten.select_scatter(self, src, dim=-1, index=1)
+
+    # Negative dimension indexing (dim=-1 is last dimension)
+    self = torch.zeros(3, 4, dtype=torch.float32, device=device)
+    src = torch.ones(3, dtype=torch.float32, device=device) * 2
+
+    check_functions_are_equivalent(fn, device, [self, src])
+
+
+def test_aten_select_scatter_negative_index(device: str):
+    """Test aten.select_scatter with negative index"""
+
+    def fn(self, src):
+        return aten.select_scatter(self, src, dim=0, index=-1)
+
+    # Negative index (index=-1 is last index)
+    self = torch.zeros(3, 4, dtype=torch.float32, device=device)
+    src = torch.ones(4, dtype=torch.float32, device=device) * 3
+
+    check_functions_are_equivalent(fn, device, [self, src])
+
+
+def test_aten_select_scatter_scalar_src(device: str):
+    """Test aten.select_scatter with scalar src (1D self)"""
+
+    def fn(self, src):
+        return aten.select_scatter(self, src, dim=0, index=1)
+
+    # When self is 1D, src is a scalar (0D tensor)
+    self = torch.zeros(3, dtype=torch.float32, device=device)
+    src = torch.tensor(5.0, dtype=torch.float32, device=device)
+
+    check_functions_are_equivalent(fn, device, [self, src])
+
+
 @pytest.mark.parametrize("repeats", [1, 2, 3, 5])
 @pytest.mark.parametrize("dim", [0, 1, -1])
 def test_aten_repeat_interleave_basic(device: str, repeats: int, dim: int):

--- a/torch_max_backend/aten_functions.py
+++ b/torch_max_backend/aten_functions.py
@@ -2221,6 +2221,55 @@ def aten_select(input: TensorValue, dim: int, index: SymIntType) -> TensorValue:
 
 
 # select_scatter(Tensor self, Tensor src, int dim, SymInt index) -> Tensor
+@map_to(aten.select_scatter)
+def aten_select_scatter(
+    input: TensorValue, src: TensorValue, dim: int, index: int
+) -> TensorValue:
+    """Embeds src values into input at the specified index along dimension dim.
+
+    This is the inverse of select: given input with shape (d0, d1, ..., d_dim, ..., dn),
+    and src with shape (d0, d1, ..., d_{dim-1}, d_{dim+1}, ..., dn),
+    returns a tensor with input's shape where input[..., index, ...] = src.
+
+    Implementation using where + mask:
+        1. Create mask that is True only at the target index along dim
+        2. Unsqueeze src to add back the dimension
+        3. Broadcast src to match input's shape
+        4. Use where to selectively replace values
+    """
+    # Handle negative dimension
+    if dim < 0:
+        dim = dim + len(input.shape)
+
+    # Handle negative index
+    dim_size = input.shape[dim]
+    if index < 0:
+        index = index + dim_size
+
+    # Step 1: Create a range tensor for the dimension to build the mask
+    indices = max_ops.range(0, dim_size, 1, dtype=DType.int64, device=input.device)
+
+    # Step 2: Create 1D boolean mask where indices == index
+    index_tensor = max_ops.constant(index, dtype=DType.int64, device=input.device)
+    mask_1d = max_ops.equal(indices, index_tensor)
+
+    # Step 3: Reshape mask to have correct broadcasting shape
+    # All dimensions except 'dim' should be 1
+    mask_shape = [StaticDim(1)] * len(input.shape)
+    mask_shape[dim] = dim_size
+    mask = max_ops.reshape(mask_1d, mask_shape)
+
+    # Step 4: Broadcast mask to input's shape
+    mask_expanded = max_ops.broadcast_to(mask, input.shape)
+
+    # Step 5: Unsqueeze src to add back the dimension
+    src_unsqueezed = max_ops.unsqueeze(src, dim)
+
+    # Step 6: Broadcast src to match input's shape
+    src_expanded = max_ops.broadcast_to(src_unsqueezed, input.shape)
+
+    # Step 7: Use where to select: where mask is True, use src, else use input
+    return max_ops.where(mask_expanded, src_expanded, input)
 
 
 # sigmoid(Tensor self) -> Tensor


### PR DESCRIPTION
The `aten.select_scatter()` algorithm:
     1. Create mask that is True only at the target index along dim
     2. Unsqueeze src to add back the dimension
     3. Broadcast src to match input's shape
     4. Use where to selectively replace values